### PR TITLE
fix: allow hero name to render on one line at large desktop viewports

### DIFF
--- a/src/components/HomeSection.vue
+++ b/src/components/HomeSection.vue
@@ -37,7 +37,7 @@ import BubbleBackground from './BubbleBackground.vue'
   padding-top: 80px;
 
   &__center {
-    max-width: 680px;
+    width: 100%;
     padding: 0 $--spacing-m;
     z-index: 1;
   }


### PR DESCRIPTION
Removed max-width: 680px from .home__center so the fluid h1 typography can expand freely without wrapping. The description paragraph retains its own max-width: 480px for readability.

https://claude.ai/code/session_01ELWZsCsyie1ehrGbnzMe7X